### PR TITLE
Separated postgres HA additional arguments and fixed isHighAvailabili…

### DIFF
--- a/api/v1alpha1/database_webhook.go
+++ b/api/v1alpha1/database_webhook.go
@@ -97,13 +97,13 @@ func (r *Database) ValidateDelete() (admission.Warnings, error) {
 }
 
 /* Checks if configured additional arguments are valid or not and returns the corresponding additional arguments. If error is nil valid, else invalid */
-func additionalArgumentsValidationCheck(isClone bool, dbType string, specifiedAdditionalArguments map[string]string) error {
+func additionalArgumentsValidationCheck(isClone bool, dbType string, isHA bool, specifiedAdditionalArguments map[string]string) error {
 	// Empty additionalArguments is always valid
 	if specifiedAdditionalArguments == nil {
 		return nil
 	}
 
-	allowedAdditionalArguments, err := util.GetAllowedAdditionalArguments(isClone, dbType)
+	allowedAdditionalArguments, err := util.GetAllowedAdditionalArguments(isClone, dbType, isHA)
 
 	// Invalid type returns error
 	if err != nil {

--- a/api/v1alpha1/webhook_helpers.go
+++ b/api/v1alpha1/webhook_helpers.go
@@ -91,7 +91,7 @@ func (v *CloningWebhookHandler) validateCreate(spec *DatabaseSpec, errors *field
 		}
 	}
 
-	if err := additionalArgumentsValidationCheck(spec.IsClone, clone.Type, clone.AdditionalArguments); err != nil {
+	if err := additionalArgumentsValidationCheck(spec.IsClone, clone.Type, clone.IsHighAvailability, clone.AdditionalArguments); err != nil {
 		*errors = append(*errors, field.Invalid(clonePath.Child("additionalArguments"), clone.AdditionalArguments, err.Error()))
 	}
 	databaselog.Info("Exiting validateCreate for clone")
@@ -230,7 +230,7 @@ func (v *ProvisioningWebhookHandler) validateCreate(spec *DatabaseSpec, errors *
 		))
 	}
 
-	if err := additionalArgumentsValidationCheck(spec.IsClone, instance.Type, instance.AdditionalArguments); err != nil {
+	if err := additionalArgumentsValidationCheck(spec.IsClone, instance.Type, instance.IsHighAvailability, instance.AdditionalArguments); err != nil {
 		*errors = append(*errors, field.Invalid(instancePath.Child("additionalArguments"), instance.AdditionalArguments, err.Error()))
 	}
 

--- a/common/util/additionalArguments.go
+++ b/common/util/additionalArguments.go
@@ -10,11 +10,12 @@ import (
 //  1. A map where the keys are the allowed additional arguments for the database type, and the corresponding values indicates whether the key is an action argument (where true=yes and false=no).
 //     Currently, all additional arguments are action arguments but this might not always be the case, thus this distinction is made so actual action arguments are appended to the appropriate provisioning body property.
 //  2. An error if there is no allowed additional arguments for the corresponding type, in other words, if the dbType is not MSSQL, MongoDB, PostGres, or MYSQL. Else nil.
-func GetAllowedAdditionalArguments(isClone bool, dbType string) (map[string]bool, error) {
+
+func GetAllowedAdditionalArguments(isClone bool, dbType string, isHa bool) (map[string]bool, error) {
 	if isClone {
 		return GetAllowedAdditionalArgumentsForClone(dbType)
 	} else {
-		return GetAllowedAdditionalArgumentsForDatabase(dbType)
+		return GetAllowedAdditionalArgumentsForDatabase(dbType, isHa)
 	}
 }
 
@@ -79,7 +80,7 @@ func GetAllowedAdditionalArgumentsForClone(dbType string) (map[string]bool, erro
 	}
 }
 
-func GetAllowedAdditionalArgumentsForDatabase(dbType string) (map[string]bool, error) {
+func GetAllowedAdditionalArgumentsForDatabase(dbType string, isHA bool) (map[string]bool, error) {
 	switch dbType {
 	case common.DATABASE_TYPE_MSSQL:
 		return map[string]bool{
@@ -104,27 +105,34 @@ func GetAllowedAdditionalArgumentsForDatabase(dbType string) (map[string]bool, e
 			"journal_size":  true,
 		}, nil
 	case common.DATABASE_TYPE_POSTGRES:
-		return map[string]bool{
-			/* Has a default */
-			"listener_port":           true,
-			"proxy_read_port":         true,
-			"proxy_write_port":        true,
-			"enable_synchronous_mode": true,
-			"auto_tune_staging_drive": true,
-			"backup_policy":           true,
-			"db_password":             true,
-			"database_names":          true,
-			"provision_virtual_ip":    true,
-			"deploy_haproxy":          true,
-			"failover_mode":           true,
-			"node_type":               true,
-			"allocate_pg_hugepage":    true,
-			"cluster_database":        true,
-			"archive_wal_expire_days": true,
-			"enable_peer_auth":        true,
-			"cluster_name":            true,
-			"patroni_cluster_name":    true,
-		}, nil
+		if isHA {
+			return map[string]bool{
+				/* Has a default */
+				"listener_port":           true,
+				"proxy_read_port":         true,
+				"proxy_write_port":        true,
+				"enable_synchronous_mode": true,
+				"auto_tune_staging_drive": true,
+				"backup_policy":           true,
+				"db_password":             true,
+				"database_names":          true,
+				"provision_virtual_ip":    true,
+				"deploy_haproxy":          true,
+				"failover_mode":           true,
+				"node_type":               true,
+				"allocate_pg_hugepage":    true,
+				"cluster_database":        true,
+				"archive_wal_expire_days": true,
+				"enable_peer_auth":        true,
+				"cluster_name":            true,
+				"patroni_cluster_name":    true,
+			}, nil
+		} else {
+			return map[string]bool{
+				/* Has a default */
+				"listener_port": true,
+			}, nil
+		}
 	case common.DATABASE_TYPE_MYSQL:
 		return map[string]bool{
 			"listener_port": true,

--- a/controller_adapters/database.go
+++ b/controller_adapters/database.go
@@ -146,10 +146,16 @@ func (d *Database) GetInstanceSize() int {
 }
 
 func (d *Database) GetInstanceIsHighAvailability() bool {
+	if d.IsClone() {
+		return d.Spec.Clone.IsHighAvailability
+	}
 	return d.Spec.Instance.IsHighAvailability
 }
 
 func (d *Database) GetInstanceNodes() []*v1alpha1.Node {
+	if d.IsClone() {
+		return d.Spec.Instance.Nodes
+	}
 	return d.Spec.Instance.Nodes
 }
 

--- a/ndb_api/db_helpers.go
+++ b/ndb_api/db_helpers.go
@@ -190,7 +190,7 @@ func setConfiguredActionArguments(database DatabaseInterface, actionArguments ma
 		return fmt.Errorf("%s! Action arguments cannot be nil", errMsgRoot)
 	}
 
-	allowedAdditionalArguments, err := util.GetAllowedAdditionalArguments(database.IsClone(), database.GetInstanceType())
+	allowedAdditionalArguments, err := util.GetAllowedAdditionalArguments(database.IsClone(), database.GetInstanceType(), database.GetInstanceIsHighAvailability())
 	if err != nil {
 		return fmt.Errorf("%s! %s", errMsgRoot, err.Error())
 	}

--- a/ndb_api/db_helpers_test.go
+++ b/ndb_api/db_helpers_test.go
@@ -141,6 +141,7 @@ func TestPostgresProvisionRequestAppender_withoutAdditionalArguments_positiveWor
 	mockDatabase.On("GetInstanceType").Return(common.DATABASE_TYPE_POSTGRES)
 	mockDatabase.On("GetAdditionalArguments").Return(map[string]string{})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "proxy_read_port",
@@ -222,6 +223,7 @@ func TestPostgresProvisionRequestAppender_withAdditionalArguments_positiveWorkfl
 		"listener_port": "0000",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 
 	expectedActionArgs := []ActionArgument{
 		{
@@ -304,6 +306,7 @@ func TestPostgresProvisionRequestAppender_withAdditionalArguments_negativeWorkfl
 		"invalid-key": "invalid-value",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	// Get specific implementation of RequestAppender
 	requestAppender, _ := GetRequestAppender(common.DATABASE_TYPE_POSTGRES, false)
 
@@ -344,6 +347,7 @@ func TestPostgresHAProvisionRequestAppender_withoutAdditionalArguments_positiveW
 	mockDatabase.On("GetInstanceNodes").Return(emptyNodes)
 	mockDatabase.On("GetClusterId").Return(TEST_CLUSTER_ID)
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(true)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "proxy_read_port",
@@ -468,6 +472,7 @@ func TestPostgresHAProvisionRequestAppender_withAdditionalArguments_positiveWork
 	})
 	mockDatabase.On("GetClusterId").Return(TEST_CLUSTER_ID)
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(true)
 
 	expectedActionArgs := []ActionArgument{
 		{
@@ -536,7 +541,7 @@ func TestPostgresHAProvisionRequestAppender_withAdditionalArguments_positiveWork
 		},
 		{
 			Name:  "cluster_name",
-			Value: "psqlcluster",
+			Value: "postgresHaCluster",
 		},
 		{
 			Name:  "patroni_cluster_name",
@@ -593,6 +598,7 @@ func TestPostgresHAProvisionRequestAppender_withoutAdditionalArguments_negativeW
 	})
 	mockDatabase.On("GetClusterId").Return(TEST_CLUSTER_ID)
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(true)
 	// Get specific implementation of RequestAppender
 	requestAppender, _ := GetRequestAppender(common.DATABASE_TYPE_POSTGRES, true)
 
@@ -644,6 +650,7 @@ func TestMSSQLProvisionRequestAppender_withoutAdditionalArguments_positiveWorklo
 	mockDatabase.On("GetInstanceType").Return(common.DATABASE_TYPE_MSSQL)
 	mockDatabase.On("GetAdditionalArguments").Return(map[string]string{})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "working_dir",
@@ -763,6 +770,7 @@ func TestMSSQLProvisionRequestAppender_withAdditionalArguments_positiveWorkflow(
 		"vm_db_server_user":         "<vm-db-server-user>",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "sql_user_name",
@@ -892,6 +900,7 @@ func TestMSSQLProvisionRequestAppender_withAdditionalArguments_negativeWorkflow(
 		"invalid-key2": "invalid-value",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	// Get specific implementation of RequestAppender
 	requestAppender, _ := GetRequestAppender(common.DATABASE_TYPE_MSSQL, false)
 
@@ -929,6 +938,7 @@ func TestMongoDbProvisionRequestAppender_withoutAdditionalArguments_positiveWork
 	mockDatabase.On("GetInstanceType").Return(common.DATABASE_TYPE_MONGODB)
 	mockDatabase.On("GetAdditionalArguments").Return(map[string]string{})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "listener_port",
@@ -1016,6 +1026,7 @@ func TestMongoDbProvisionRequestAppender_withAdditionalArguments_positiveWorkflo
 		"journal_size":  "1",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "listener_port",
@@ -1101,6 +1112,7 @@ func TestMongoDbProvisionRequestAppender_withAdditionalArguments_negativeWorkflo
 		"invalid-key": "invalid-value",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	// Get specific implementation of RequestAppender
 	requestAppender, _ := GetRequestAppender(common.DATABASE_TYPE_MONGODB, false)
 
@@ -1137,6 +1149,7 @@ func TestMySqlProvisionRequestAppender_withoutAdditionalArguments_positiveWorkfl
 	mockDatabase.On("GetInstanceType").Return(common.DATABASE_TYPE_MYSQL)
 	mockDatabase.On("GetAdditionalArguments").Return(map[string]string{})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "listener_port",
@@ -1202,6 +1215,7 @@ func TestMySqlProvisionRequestAppender_withAdditionalArguments_positiveWorkflow(
 		"listener_port": "1111",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	expectedActionArgs := []ActionArgument{
 		{
 			Name:  "listener_port",
@@ -1267,6 +1281,7 @@ func TestMySqlProvisionRequestAppender_withAdditionalArguments_negativeWorkflow(
 		"invalid-key": "invalid-value",
 	})
 	mockDatabase.On("IsClone").Return(false)
+	mockDatabase.On("GetInstanceIsHighAvailability").Return(false)
 	// Get specific implementation of RequestAppender
 	requestAppender, _ := GetRequestAppender(common.DATABASE_TYPE_MYSQL, false)
 


### PR DESCRIPTION
…ty and getInstanceNodes getter methods

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/ndb-operator/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```